### PR TITLE
try a new macro style to maybe help windows users

### DIFF
--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -1418,8 +1418,8 @@ sv_twobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 {
     uint16_t nw = n[0] << 8 | n[1];
     uint16_t hw = h[0] << 8 | h[1];
-    size_t i = 0;
-    for (h++, i++; i < sz && *h && hw != nw; hw = (hw << 8) | *++h, ++i)
+    size_t i = 1;
+    for (h++; i < sz && *h && hw != nw; hw = (hw << 8) | *++h, ++i)
     {}
     return (i < sz) ? i - 1 : sz;
 }
@@ -1448,8 +1448,8 @@ sv_threebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8;
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8;
-    size_t i = 0;
-    for (h += 2, i += 2; i < sz && *h && hw != nw; hw = (hw | *++h) << 8, ++i)
+    size_t i = 2;
+    for (h += 2; i < sz && *h && hw != nw; hw = (hw | *++h) << 8, ++i)
     {}
     return (i < sz) ? i - 2 : sz;
 }
@@ -1478,8 +1478,8 @@ sv_fourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8 | h[3];
-    size_t i = 0;
-    for (h += 3, i += 3; i < sz && *h && hw != nw; hw = (hw << 8) | *++h, ++i)
+    size_t i = 3;
+    for (h += 3; i < sz && *h && hw != nw; hw = (hw << 8) | *++h, ++i)
     {}
     return (i < sz) ? i - 3 : sz;
 }

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -22,24 +22,24 @@
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, GEQ(arr, size))`. */
-#    define GEQ(str, size) str[static(size)]
+   a parameter such as `void func(int size, ARR_GEQ(arr, size))`. */
+#    define ARR_GEQ(str, size) str[static(size)]
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, int arr[STATIC_CONST(size)])`.
+   a parameter such as `void func(int size, int ARR_GEQ(arr,size))`.
    This declarations adds the additional constraint that the pointer
    to the begginning of the array of types will not move. */
-#    define CONST_GEQ(str, size) str[static const(size)]
+#    define ARR_CONST_GEQ(str, size) str[static const(size)]
 #else
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. Compiler warnings may differ from GCC/Clang. */
-#    define GEQ(str, size) *str
+#    define ARR_GEQ(str, size) *str
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. MSVC does not allow specification of a const
    pointer to the begginning of an array function parameter when using array
    size parameter syntax. Compiler warnings may differ from GCC/Clang. */
-#    define CONST_GEQ(str, size) *const str
+#    define ARR_CONST_GEQ(str, size) *const str
 #endif
 
 /* ========================   Type Definitions   =========================== */
@@ -72,58 +72,62 @@ static int64_t sv_ssizet_max(int64_t, int64_t);
    by assuming the strings are GREATER than or EQUAL TO certain lenghts
    allowing for processing by larger units than 1 in compiled code. */
 
-static size_t sv_pos_memo(int64_t hay_sz, char const GEQ(, hay_sz),
-                          int64_t needle_sz, char const GEQ(, needle_sz),
+static size_t sv_pos_memo(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                           int64_t, int64_t);
-static size_t sv_pos_normal(int64_t hay_sz, char const GEQ(, hay_sz),
-                            int64_t needle_sz, char const GEQ(, needle_sz),
+static size_t sv_pos_normal(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                            int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                             int64_t, int64_t);
-static size_t sv_rpos_memo(int64_t hay_sz, char const GEQ(, hay_sz),
-                           int64_t needle_sz, char const GEQ(, needle_sz),
+static size_t sv_rpos_memo(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                            int64_t, int64_t);
-static size_t sv_rpos_normal(int64_t hay_sz, char const GEQ(, hay_sz),
-                             int64_t needle_sz, char const GEQ(, needle_sz),
+static size_t sv_rpos_normal(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                             int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                              int64_t, int64_t);
-static size_t sv_tw_match(int64_t hay_sz, char const GEQ(, hay_sz),
-                          int64_t needle_sz, char const GEQ(, needle_sz));
-static size_t sv_tw_rmatch(int64_t hay_sz, char const GEQ(, hay_sz),
-                           int64_t needle_sz, char const GEQ(, needle_sz));
-static struct sv_factorization sv_maximal_suffix(int64_t needle_sz,
-                                                 char const GEQ(, needle_sz));
+static size_t sv_tw_match(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_tw_rmatch(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix_rev(int64_t needle_sz, char const GEQ(, needle_sz));
-static struct sv_factorization sv_rmaximal_suffix(int64_t needle_sz,
-                                                  char const GEQ(, needle_sz));
+sv_maximal_suffix(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix_rev(int64_t needle_sz, char const GEQ(, needle_sz));
+sv_maximal_suffix_rev(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static struct sv_factorization
+sv_rmaximal_suffix(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static struct sv_factorization
+sv_rmaximal_suffix_rev(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static size_t sv_twobyte_strnstrn(size_t hay_sz,
-                                  unsigned char const GEQ(, hay_sz),
-                                  size_t n_sz, unsigned char const GEQ(, n_sz));
-static size_t sv_threebyte_strnstrn(size_t sz, unsigned char const GEQ(, sz),
+                                  unsigned char const ARR_GEQ(, hay_sz),
+                                  size_t n_sz,
+                                  unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_threebyte_strnstrn(size_t sz,
+                                    unsigned char const ARR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const GEQ(, n_sz));
-static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const GEQ(, sz),
+                                    unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const ARR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const GEQ(, n_sz));
-static size_t sv_strcspn(size_t str_sz, char const GEQ(, str_sz), size_t set_sz,
-                         char const GEQ(, set_sz));
-static size_t sv_strspn(size_t str_sz, char const GEQ(, str_sz), size_t set_sz,
-                        char const GEQ(, set_sz));
-static size_t sv_strnstrn(int64_t hay_sz, char const GEQ(, hay_sz),
-                          int64_t needle_sz, char const GEQ(, needle_sz));
-static size_t sv_strnchr(size_t n, char const GEQ(, n), char);
-static size_t sv_rstrnchr(size_t n, char const GEQ(, n), char);
-static size_t sv_rstrnstrn(int64_t hay_sz, char const GEQ(, hay_sz),
-                           int64_t needle_sz, char const GEQ(, needle_sz));
-static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const GEQ(, sz),
+                                   unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_strcspn(size_t str_sz, char const ARR_GEQ(, str_sz),
+                         size_t set_sz, char const ARR_GEQ(, set_sz));
+static size_t sv_strspn(size_t str_sz, char const ARR_GEQ(, str_sz),
+                        size_t set_sz, char const ARR_GEQ(, set_sz));
+static size_t sv_strnstrn(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_strnchr(size_t n, char const ARR_GEQ(, n), char);
+static size_t sv_rstrnchr(size_t n, char const ARR_GEQ(, n), char);
+static size_t sv_rstrnstrn(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const ARR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const GEQ(, n_sz));
-static size_t sv_rthreebyte_strnstrn(size_t sz, unsigned char const GEQ(, sz),
+                                   unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_rthreebyte_strnstrn(size_t sz,
+                                     unsigned char const ARR_GEQ(, sz),
                                      size_t n_sz,
-                                     unsigned char const GEQ(, n_sz));
-static size_t sv_rfourbyte_strnstrn(size_t sz, unsigned char const GEQ(, sz),
+                                     unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_rfourbyte_strnstrn(size_t sz,
+                                    unsigned char const ARR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const GEQ(, n_sz));
+                                    unsigned char const ARR_GEQ(, n_sz));
 
 /* ===================   Interface Implementation   ====================== */
 
@@ -862,8 +866,8 @@ sv_rmemcmp(void const *const vl, void const *const vr, size_t n)
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strcspn(size_t const str_sz, char const CONST_GEQ(str, str_sz),
-           size_t const set_sz, char const GEQ(set, set_sz))
+sv_strcspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
+           size_t const set_sz, char const ARR_GEQ(set, set_sz))
 {
     if (!set_sz)
     {
@@ -895,8 +899,8 @@ sv_strcspn(size_t const str_sz, char const CONST_GEQ(str, str_sz),
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strspn(size_t const str_sz, char const CONST_GEQ(str, str_sz),
-          size_t const set_sz, char const GEQ(set, set_sz))
+sv_strspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
+          size_t const set_sz, char const ARR_GEQ(set, set_sz))
 {
     char const *a = str;
     size_t byteset[32 / sizeof(size_t)] = {0};
@@ -926,8 +930,9 @@ sv_strspn(size_t const str_sz, char const CONST_GEQ(str, str_sz),
    hay length. Returns 0 based index position at which needle begins in
    hay if it can be found, otherwise the hay size is returned. */
 static size_t
-sv_strnstrn(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-            int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz))
+sv_strnstrn(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
+            char const ARR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -961,8 +966,9 @@ sv_strnstrn(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
    the start of the reverse two-way algorithm for more. May unite if
    a clean way exists. */
 static size_t
-sv_rstrnstrn(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-             int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz))
+sv_rstrnstrn(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
+             char const ARR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -1018,8 +1024,9 @@ sv_rstrnstrn(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
    an entire string. Returns the position at which needle begins if found
    and the size of the hay stack if not found. */
 static inline size_t
-sv_tw_match(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-            int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz))
+sv_tw_match(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
+            char const ARR_CONST_GEQ(needle, needle_sz))
 {
     /* Preprocessing to get critical position and period distance. */
     struct sv_factorization const s = sv_maximal_suffix(needle_sz, needle);
@@ -1038,8 +1045,9 @@ sv_tw_match(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_memo(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-            int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz),
+sv_pos_memo(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
+            char const ARR_CONST_GEQ(needle, needle_sz),
             int64_t const period_dist, int64_t const critical_pos)
 {
     int64_t lpos = 0;
@@ -1080,9 +1088,10 @@ sv_pos_memo(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_normal(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-              int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz),
-              int64_t period_dist, int64_t const critical_pos)
+sv_pos_normal(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+              int64_t const needle_sz,
+              char const ARR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+              int64_t const critical_pos)
 {
     period_dist
         = sv_ssizet_max(critical_pos + 1, needle_sz - critical_pos - 1) + 1;
@@ -1121,7 +1130,7 @@ sv_pos_normal(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix(int64_t const needle_sz,
-                  char const CONST_GEQ(needle, needle_sz))
+                  char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1165,7 +1174,7 @@ sv_maximal_suffix(int64_t const needle_sz,
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix_rev(int64_t const needle_sz,
-                      char const CONST_GEQ(needle, needle_sz))
+                      char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1243,8 +1252,9 @@ sv_maximal_suffix_rev(int64_t const needle_sz,
 /* Searches a string from right to left with a two-way algorithm. Returns
    the position of the start of the strig if found and string size if not. */
 static inline size_t
-sv_tw_rmatch(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-             int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz))
+sv_tw_rmatch(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
+             char const ARR_CONST_GEQ(needle, needle_sz))
 {
     struct sv_factorization const s = sv_rmaximal_suffix(needle_sz, needle);
     struct sv_factorization const r = sv_rmaximal_suffix_rev(needle_sz, needle);
@@ -1260,8 +1270,9 @@ sv_tw_rmatch(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_memo(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-             int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz),
+sv_rpos_memo(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
+             char const ARR_CONST_GEQ(needle, needle_sz),
              int64_t const period_dist, int64_t const critical_pos)
 {
     int64_t lpos = 0;
@@ -1303,9 +1314,10 @@ sv_rpos_memo(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_normal(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
-               int64_t const needle_sz, char const CONST_GEQ(needle, needle_sz),
-               int64_t period_dist, int64_t const critical_pos)
+sv_rpos_normal(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
+               int64_t const needle_sz,
+               char const ARR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+               int64_t const critical_pos)
 {
     period_dist
         = sv_ssizet_max(critical_pos + 1, needle_sz - critical_pos - 1) + 1;
@@ -1346,7 +1358,7 @@ sv_rpos_normal(int64_t const hay_sz, char const CONST_GEQ(hay, hay_sz),
 
 static inline struct sv_factorization
 sv_rmaximal_suffix(int64_t const needle_sz,
-                   char const CONST_GEQ(needle, needle_sz))
+                   char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1388,7 +1400,7 @@ sv_rmaximal_suffix(int64_t const needle_sz,
 
 static inline struct sv_factorization
 sv_rmaximal_suffix_rev(int64_t const needle_sz,
-                       char const CONST_GEQ(needle, needle_sz))
+                       char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1440,7 +1452,7 @@ sv_rmaximal_suffix_rev(int64_t const needle_sz,
    to left. Also having a reverse tokenizer is convenient and also relies
    on right to left brute force searches. */
 static inline size_t
-sv_strnchr(size_t n, char const GEQ(s, n), char const c)
+sv_strnchr(size_t n, char const ARR_GEQ(s, n), char const c)
 {
     size_t i = 0;
     for (; n && *s != c; s++, --n, ++i)
@@ -1449,7 +1461,7 @@ sv_strnchr(size_t n, char const GEQ(s, n), char const c)
 }
 
 static inline size_t
-sv_rstrnchr(size_t const n, char const CONST_GEQ(s, n), char const c)
+sv_rstrnchr(size_t const n, char const ARR_CONST_GEQ(s, n), char const c)
 {
     char const *x = s + n - 1;
     size_t i = n;
@@ -1459,8 +1471,9 @@ sv_rstrnchr(size_t const n, char const CONST_GEQ(s, n), char const c)
 }
 
 static inline size_t
-sv_twobyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
-                    size_t const n_sz, unsigned char const CONST_GEQ(n, n_sz))
+sv_twobyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
+                    size_t const n_sz,
+                    unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint16_t nw = n[0] << 8 | n[1];
     uint16_t hw = h[0] << 8 | h[1];
@@ -1471,8 +1484,9 @@ sv_twobyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
 }
 
 static inline size_t
-sv_rtwobyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
-                     size_t const n_sz, unsigned char const CONST_GEQ(n, n_sz))
+sv_rtwobyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
+                     size_t const n_sz,
+                     unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 2;
     uint16_t nw = n[0] << 8 | n[1];
@@ -1487,8 +1501,9 @@ sv_rtwobyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
 }
 
 static inline size_t
-sv_threebyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
-                      size_t const n_sz, unsigned char const CONST_GEQ(n, n_sz))
+sv_threebyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
+                      size_t const n_sz,
+                      unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8;
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8;
@@ -1499,9 +1514,9 @@ sv_threebyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
 }
 
 static inline size_t
-sv_rthreebyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
+sv_rthreebyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                        size_t const n_sz,
-                       unsigned char const CONST_GEQ(n, n_sz))
+                       unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 3;
     uint32_t nw = (uint32_t)n[0] << 16 | n[1] << 8 | n[2];
@@ -1516,8 +1531,9 @@ sv_rthreebyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
 }
 
 static inline size_t
-sv_fourbyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
-                     size_t const n_sz, unsigned char const CONST_GEQ(n, n_sz))
+sv_fourbyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
+                     size_t const n_sz,
+                     unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8 | h[3];
@@ -1528,8 +1544,9 @@ sv_fourbyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
 }
 
 static inline size_t
-sv_rfourbyte_strnstrn(size_t const sz, unsigned char const GEQ(h, sz),
-                      size_t const n_sz, unsigned char const CONST_GEQ(n, n_sz))
+sv_rfourbyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
+                      size_t const n_sz,
+                      unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 4;
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -35,79 +35,79 @@ static size_t sv_before_rfind(str_view, str_view);
 static size_t sv_min(size_t, size_t);
 static sv_threeway_cmp sv_char_cmp(char, char);
 static int64_t sv_ssizet_max(int64_t, int64_t);
-static size_t sv_pos_memo(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+static size_t sv_pos_memo(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                           int64_t, int64_t);
-static size_t sv_pos_normal(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                            int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+static size_t sv_pos_normal(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                            int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                             int64_t, int64_t);
-static size_t sv_rpos_memo(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+static size_t sv_rpos_memo(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                            int64_t, int64_t);
-static size_t sv_rpos_normal(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                             int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+static size_t sv_rpos_normal(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                             int64_t needle_sz, char const ARR_GEQ(, needle_sz),
                              int64_t, int64_t);
-static size_t sv_tw_match(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          int64_t needle_sz, char const PTR_GEQ(, needle_sz));
-static size_t sv_tw_rmatch(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_tw_match(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_tw_rmatch(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_maximal_suffix(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix_rev(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_maximal_suffix_rev(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_rmaximal_suffix(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix_rev(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_rmaximal_suffix_rev(int64_t needle_sz, char const ARR_GEQ(, needle_sz));
 static size_t sv_twobyte_strnstrn(size_t hay_sz,
-                                  unsigned char const PTR_GEQ(, hay_sz),
+                                  unsigned char const ARR_GEQ(, hay_sz),
                                   size_t n_sz,
-                                  unsigned char const PTR_GEQ(, n_sz));
+                                  unsigned char const ARR_GEQ(, n_sz));
 static size_t sv_threebyte_strnstrn(size_t sz,
-                                    unsigned char const PTR_GEQ(, sz),
+                                    unsigned char const ARR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const PTR_GEQ(, n_sz));
-static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const PTR_GEQ(, sz),
+                                    unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const ARR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const PTR_GEQ(, n_sz));
-static size_t sv_strcspn(size_t str_sz, char const PTR_GEQ(, str_sz),
-                         size_t set_sz, char const PTR_GEQ(, set_sz));
-static size_t sv_strspn(size_t str_sz, char const PTR_GEQ(, str_sz),
-                        size_t set_sz, char const PTR_GEQ(, set_sz));
-static size_t sv_strnstrn(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          int64_t needle_sz, char const PTR_GEQ(, needle_sz));
-static size_t sv_strnchr(size_t n, char const PTR_GEQ(, n), char);
-static size_t sv_rstrnchr(size_t n, char const PTR_GEQ(, n), char);
-static size_t sv_rstrnstrn(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           int64_t needle_sz, char const PTR_GEQ(, needle_sz));
-static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const PTR_GEQ(, sz),
+                                   unsigned char const ARR_GEQ(, n_sz));
+static size_t sv_strcspn(size_t str_sz, char const ARR_GEQ(, str_sz),
+                         size_t set_sz, char const ARR_GEQ(, set_sz));
+static size_t sv_strspn(size_t str_sz, char const ARR_GEQ(, str_sz),
+                        size_t set_sz, char const ARR_GEQ(, set_sz));
+static size_t sv_strnstrn(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_strnchr(size_t n, char const ARR_GEQ(, n), char);
+static size_t sv_rstrnchr(size_t n, char const ARR_GEQ(, n), char);
+static size_t sv_rstrnstrn(int64_t hay_sz, char const ARR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const ARR_GEQ(, needle_sz));
+static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const ARR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const PTR_GEQ(, n_sz));
+                                   unsigned char const ARR_GEQ(, n_sz));
 static size_t sv_rthreebyte_strnstrn(size_t sz,
-                                     unsigned char const PTR_GEQ(, sz),
+                                     unsigned char const ARR_GEQ(, sz),
                                      size_t n_sz,
-                                     unsigned char const PTR_GEQ(, n_sz));
+                                     unsigned char const ARR_GEQ(, n_sz));
 static size_t sv_rfourbyte_strnstrn(size_t sz,
-                                    unsigned char const PTR_GEQ(, sz),
+                                    unsigned char const ARR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const PTR_GEQ(, n_sz));
+                                    unsigned char const ARR_GEQ(, n_sz));
 
 /* ===================   Interface Implementation   ====================== */
 
 str_view
-sv(char const PTR_GEQ(str, 1))
+sv(char const ARR_GEQ(str, 1))
 {
     return (str_view){.s = str, .sz = strlen(str)};
 }
 
 str_view
-sv_n(size_t n, char const PTR_GEQ(str, 1))
+sv_n(size_t n, char const ARR_GEQ(str, 1))
 {
     return (str_view){.s = str, .sz = strnlen(str, n)};
 }
 
 str_view
-sv_delim(char const PTR_GEQ(str, 1), char const PTR_GEQ(delim, 1))
+sv_delim(char const ARR_GEQ(str, 1), char const ARR_GEQ(delim, 1))
 {
     return sv_begin_tok((str_view){.s = str, .sz = strlen(str)},
                         (str_view){.s = delim, .sz = strlen(delim)});
@@ -126,13 +126,13 @@ sv_print(FILE *f, str_view const sv)
 }
 
 str_view
-sv_copy(size_t const str_sz, char const PTR_GEQ(src_str, 1))
+sv_copy(size_t const str_sz, char const ARR_GEQ(src_str, 1))
 {
     return sv_n(str_sz, src_str);
 }
 
 size_t
-sv_fill(size_t const dest_sz, char PTR_CONST_GEQ(dest_buf, dest_sz),
+sv_fill(size_t const dest_sz, char ARR_CONST_GEQ(dest_buf, dest_sz),
         str_view const src)
 {
     if (!dest_sz || !src.s || !src.sz)
@@ -164,13 +164,13 @@ sv_size(str_view const sv)
 }
 
 size_t
-sv_strsize(char const PTR_GEQ(str, 1))
+sv_strsize(char const ARR_GEQ(str, 1))
 {
     return strlen(str) + 1;
 }
 
 size_t
-sv_minlen(char const PTR_GEQ(str, 1), size_t n)
+sv_minlen(char const ARR_GEQ(str, 1), size_t n)
 {
     return strnlen(str, n);
 }
@@ -192,9 +192,9 @@ sv_null(void)
 }
 
 void
-sv_swap(str_view PTR_GEQ(a, 1), str_view PTR_GEQ(b, 1))
+sv_swap(str_view *const a, str_view *const b)
 {
-    if (a == b)
+    if (a == b || !a || !b)
     {
         return;
     }
@@ -228,7 +228,7 @@ sv_cmp(str_view const lhs, str_view const rhs)
 }
 
 sv_threeway_cmp
-sv_strcmp(str_view const lhs, char const PTR_GEQ(rhs, 1))
+sv_strcmp(str_view const lhs, char const ARR_GEQ(rhs, 1))
 {
     if (!lhs.s)
     {
@@ -250,7 +250,7 @@ sv_strcmp(str_view const lhs, char const PTR_GEQ(rhs, 1))
 }
 
 sv_threeway_cmp
-sv_strncmp(str_view const lhs, char const PTR_GEQ(rhs, 1), size_t const n)
+sv_strncmp(str_view const lhs, char const ARR_GEQ(rhs, 1), size_t const n)
 {
     if (!lhs.s)
     {
@@ -313,7 +313,7 @@ sv_end(str_view const sv)
 }
 
 char const *
-sv_next(char const PTR_GEQ(c, 1))
+sv_next(char const ARR_GEQ(c, 1))
 {
     return ++c;
 }
@@ -347,7 +347,7 @@ sv_rend(str_view const sv)
 }
 
 char const *
-sv_rnext(char const PTR_GEQ(c, 1))
+sv_rnext(char const ARR_GEQ(c, 1))
 {
     return --c;
 }
@@ -802,8 +802,8 @@ sv_rmemcmp(void const *const vl, void const *const vr, size_t n)
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strcspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
-           size_t const set_sz, char const PTR_GEQ(set, set_sz))
+sv_strcspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
+           size_t const set_sz, char const ARR_GEQ(set, set_sz))
 {
     if (!set_sz)
     {
@@ -835,8 +835,8 @@ sv_strcspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
-          size_t const set_sz, char const PTR_GEQ(set, set_sz))
+sv_strspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
+          size_t const set_sz, char const ARR_GEQ(set, set_sz))
 {
     char const *a = str;
     size_t byteset[32 / sizeof(size_t)] = {0};
@@ -866,9 +866,9 @@ sv_strspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
    hay length. Returns 0 based index position at which needle begins in
    hay if it can be found, otherwise the hay size is returned. */
 static size_t
-sv_strnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_strnstrn(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
             int64_t const needle_sz,
-            char const PTR_CONST_GEQ(needle, needle_sz))
+            char const ARR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -902,9 +902,9 @@ sv_strnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
    the start of the reverse two-way algorithm for more. May unite if
    a clean way exists. */
 static size_t
-sv_rstrnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_rstrnstrn(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
              int64_t const needle_sz,
-             char const PTR_CONST_GEQ(needle, needle_sz))
+             char const ARR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -960,9 +960,9 @@ sv_rstrnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
    an entire string. Returns the position at which needle begins if found
    and the size of the hay stack if not found. */
 static inline size_t
-sv_tw_match(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_tw_match(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
             int64_t const needle_sz,
-            char const PTR_CONST_GEQ(needle, needle_sz))
+            char const ARR_CONST_GEQ(needle, needle_sz))
 {
     /* Preprocessing to get critical position and period distance. */
     struct sv_factorization const s = sv_maximal_suffix(needle_sz, needle);
@@ -981,9 +981,9 @@ sv_tw_match(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_pos_memo(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
             int64_t const needle_sz,
-            char const PTR_CONST_GEQ(needle, needle_sz),
+            char const ARR_CONST_GEQ(needle, needle_sz),
             int64_t const period_dist, int64_t const critical_pos)
 {
     int64_t lpos = 0;
@@ -1024,9 +1024,9 @@ sv_pos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_pos_normal(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
               int64_t const needle_sz,
-              char const PTR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+              char const ARR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
               int64_t const critical_pos)
 {
     period_dist
@@ -1066,7 +1066,7 @@ sv_pos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix(int64_t const needle_sz,
-                  char const PTR_CONST_GEQ(needle, needle_sz))
+                  char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1110,7 +1110,7 @@ sv_maximal_suffix(int64_t const needle_sz,
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix_rev(int64_t const needle_sz,
-                      char const PTR_CONST_GEQ(needle, needle_sz))
+                      char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1188,9 +1188,9 @@ sv_maximal_suffix_rev(int64_t const needle_sz,
 /* Searches a string from right to left with a two-way algorithm. Returns
    the position of the start of the strig if found and string size if not. */
 static inline size_t
-sv_tw_rmatch(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_tw_rmatch(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
              int64_t const needle_sz,
-             char const PTR_CONST_GEQ(needle, needle_sz))
+             char const ARR_CONST_GEQ(needle, needle_sz))
 {
     struct sv_factorization const s = sv_rmaximal_suffix(needle_sz, needle);
     struct sv_factorization const r = sv_rmaximal_suffix_rev(needle_sz, needle);
@@ -1206,9 +1206,9 @@ sv_tw_rmatch(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_rpos_memo(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
              int64_t const needle_sz,
-             char const PTR_CONST_GEQ(needle, needle_sz),
+             char const ARR_CONST_GEQ(needle, needle_sz),
              int64_t const period_dist, int64_t const critical_pos)
 {
     int64_t lpos = 0;
@@ -1250,9 +1250,9 @@ sv_rpos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+sv_rpos_normal(int64_t const hay_sz, char const ARR_CONST_GEQ(hay, hay_sz),
                int64_t const needle_sz,
-               char const PTR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+               char const ARR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
                int64_t const critical_pos)
 {
     period_dist
@@ -1294,7 +1294,7 @@ sv_rpos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 
 static inline struct sv_factorization
 sv_rmaximal_suffix(int64_t const needle_sz,
-                   char const PTR_CONST_GEQ(needle, needle_sz))
+                   char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1336,7 +1336,7 @@ sv_rmaximal_suffix(int64_t const needle_sz,
 
 static inline struct sv_factorization
 sv_rmaximal_suffix_rev(int64_t const needle_sz,
-                       char const PTR_CONST_GEQ(needle, needle_sz))
+                       char const ARR_CONST_GEQ(needle, needle_sz))
 {
     int64_t suff_pos = -1;
     int64_t period = 1;
@@ -1388,7 +1388,7 @@ sv_rmaximal_suffix_rev(int64_t const needle_sz,
    to left. Also having a reverse tokenizer is convenient and also relies
    on right to left brute force searches. */
 static inline size_t
-sv_strnchr(size_t n, char const PTR_GEQ(s, n), char const c)
+sv_strnchr(size_t n, char const ARR_GEQ(s, n), char const c)
 {
     size_t i = 0;
     for (; n && *s != c; s++, --n, ++i)
@@ -1397,7 +1397,7 @@ sv_strnchr(size_t n, char const PTR_GEQ(s, n), char const c)
 }
 
 static inline size_t
-sv_rstrnchr(size_t const n, char const PTR_CONST_GEQ(s, n), char const c)
+sv_rstrnchr(size_t const n, char const ARR_CONST_GEQ(s, n), char const c)
 {
     char const *x = s + n - 1;
     size_t i = n;
@@ -1407,9 +1407,9 @@ sv_rstrnchr(size_t const n, char const PTR_CONST_GEQ(s, n), char const c)
 }
 
 static inline size_t
-sv_twobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_twobyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                     size_t const n_sz,
-                    unsigned char const PTR_CONST_GEQ(n, n_sz))
+                    unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint16_t nw = n[0] << 8 | n[1];
     uint16_t hw = h[0] << 8 | h[1];
@@ -1420,9 +1420,9 @@ sv_twobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_rtwobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_rtwobyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                      size_t const n_sz,
-                     unsigned char const PTR_CONST_GEQ(n, n_sz))
+                     unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 2;
     uint16_t nw = n[0] << 8 | n[1];
@@ -1437,9 +1437,9 @@ sv_rtwobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_threebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_threebyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                       size_t const n_sz,
-                      unsigned char const PTR_CONST_GEQ(n, n_sz))
+                      unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8;
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8;
@@ -1450,9 +1450,9 @@ sv_threebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_rthreebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_rthreebyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                        size_t const n_sz,
-                       unsigned char const PTR_CONST_GEQ(n, n_sz))
+                       unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 3;
     uint32_t nw = (uint32_t)n[0] << 16 | n[1] << 8 | n[2];
@@ -1467,9 +1467,9 @@ sv_rthreebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_fourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_fourbyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                      size_t const n_sz,
-                     unsigned char const PTR_CONST_GEQ(n, n_sz))
+                     unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8 | h[3];
@@ -1480,9 +1480,9 @@ sv_fourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_rfourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
+sv_rfourbyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
                       size_t const n_sz,
-                      unsigned char const PTR_CONST_GEQ(n, n_sz))
+                      unsigned char const ARR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 4;
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -40,85 +40,88 @@ static size_t sv_before_rfind(str_view, str_view);
 static size_t sv_min(size_t, size_t);
 static sv_threeway_cmp sv_char_cmp(char, char);
 static ssize_t sv_ssizet_max(ssize_t, ssize_t);
-static size_t sv_pos_memo(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                          ssize_t needle_sz, char const[STATIC(needle_sz)],
+static size_t sv_pos_memo(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
                           ssize_t, ssize_t);
-static size_t sv_pos_normal(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                            ssize_t needle_sz, char const[STATIC(needle_sz)],
+static size_t sv_pos_normal(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                            ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
                             ssize_t, ssize_t);
-static size_t sv_rpos_memo(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                           ssize_t needle_sz, char const[STATIC(needle_sz)],
+static size_t sv_rpos_memo(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
                            ssize_t, ssize_t);
-static size_t sv_rpos_normal(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                             ssize_t needle_sz, char const[STATIC(needle_sz)],
+static size_t sv_rpos_normal(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                             ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
                              ssize_t, ssize_t);
-static size_t sv_tw_match(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                          ssize_t needle_sz, char const[STATIC(needle_sz)]);
-static size_t sv_tw_rmatch(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                           ssize_t needle_sz, char const[STATIC(needle_sz)]);
-static struct sv_factorization sv_maximal_suffix(ssize_t needle_sz,
-                                                 char const[STATIC(needle_sz)]);
+static size_t sv_tw_match(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_tw_rmatch(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix_rev(ssize_t needle_sz, char const[STATIC(needle_sz)]);
+sv_maximal_suffix(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix(ssize_t needle_sz, char const[STATIC(needle_sz)]);
+sv_maximal_suffix_rev(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix_rev(ssize_t needle_sz, char const[STATIC(needle_sz)]);
+sv_rmaximal_suffix(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static struct sv_factorization
+sv_rmaximal_suffix_rev(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
 static size_t sv_twobyte_strnstrn(size_t hay_sz,
-                                  unsigned char const[STATIC(hay_sz)],
+                                  unsigned char const PTR_GEQ(, hay_sz),
                                   size_t n_sz,
-                                  unsigned char const[STATIC(n_sz)]);
-static size_t sv_threebyte_strnstrn(size_t sz, unsigned char const[STATIC(sz)],
+                                  unsigned char const PTR_GEQ(, n_sz));
+static size_t sv_threebyte_strnstrn(size_t sz,
+                                    unsigned char const PTR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const[STATIC(n_sz)]);
-static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const[STATIC(sz)],
+                                    unsigned char const PTR_GEQ(, n_sz));
+static size_t sv_fourbyte_strnstrn(size_t sz, unsigned char const PTR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const[STATIC(n_sz)]);
-static size_t sv_strcspn(size_t str_sz, char const[STATIC(str_sz)],
-                         size_t set_sz, char const[STATIC(set_sz)]);
-static size_t sv_strspn(size_t str_sz, char const[STATIC(str_sz)],
-                        size_t set_sz, char const[STATIC(set_sz)]);
-static size_t sv_strnstrn(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                          ssize_t needle_sz, char const[STATIC(needle_sz)]);
-static size_t sv_strnchr(size_t n, char const[STATIC(n)], char);
-static size_t sv_rstrnchr(size_t n, char const[STATIC(n)], char);
-static size_t sv_rstrnstrn(ssize_t hay_sz, char const[STATIC(hay_sz)],
-                           ssize_t needle_sz, char const[STATIC(needle_sz)]);
-static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const[STATIC(sz)],
+                                   unsigned char const PTR_GEQ(, n_sz));
+static size_t sv_strcspn(size_t str_sz, char const PTR_GEQ(, str_sz),
+                         size_t set_sz, char const PTR_GEQ(, set_sz));
+static size_t sv_strspn(size_t str_sz, char const PTR_GEQ(, str_sz),
+                        size_t set_sz, char const PTR_GEQ(, set_sz));
+static size_t sv_strnstrn(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_strnchr(size_t n, char const PTR_GEQ(, n), char);
+static size_t sv_rstrnchr(size_t n, char const PTR_GEQ(, n), char);
+static size_t sv_rstrnstrn(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const PTR_GEQ(, sz),
                                    size_t n_sz,
-                                   unsigned char const[STATIC(n_sz)]);
-static size_t sv_rthreebyte_strnstrn(size_t sz, unsigned char const[STATIC(sz)],
+                                   unsigned char const PTR_GEQ(, n_sz));
+static size_t sv_rthreebyte_strnstrn(size_t sz,
+                                     unsigned char const PTR_GEQ(, sz),
                                      size_t n_sz,
-                                     unsigned char const[STATIC(n_sz)]);
-static size_t sv_rfourbyte_strnstrn(size_t sz, unsigned char const[STATIC(sz)],
+                                     unsigned char const PTR_GEQ(, n_sz));
+static size_t sv_rfourbyte_strnstrn(size_t sz,
+                                    unsigned char const PTR_GEQ(, sz),
                                     size_t n_sz,
-                                    unsigned char const[STATIC(n_sz)]);
+                                    unsigned char const PTR_GEQ(, n_sz));
 
 /* ===================   Interface Implementation   ====================== */
 
 str_view
-sv(char const str[STATIC_CONST(1)])
+sv(char const PTR_GEQ(str, 1))
 {
     return (str_view){.s = str, .sz = strlen(str)};
 }
 
 str_view
-sv_n(size_t n, char const str[STATIC_CONST(1)])
+sv_n(size_t n, char const PTR_GEQ(str, 1))
 {
     return (str_view){.s = str, .sz = strnlen(str, n)};
 }
 
 str_view
-sv_delim(char const str[STATIC_CONST(1)], char const delim[STATIC_CONST(1)])
+sv_delim(char const PTR_GEQ(str, 1), char const PTR_GEQ(delim, 1))
 {
     return sv_begin_tok((str_view){.s = str, .sz = strlen(str)},
                         (str_view){.s = delim, .sz = strlen(delim)});
 }
 
 void
-sv_print(FILE f[STATIC_CONST(1)], str_view const sv)
+sv_print(FILE *f, str_view const sv)
 {
-    if (!sv.s || nil.s == sv.s || !sv.sz)
+    if (!f || !sv.s || nil.s == sv.s || !sv.sz)
     {
         return;
     }
@@ -128,13 +131,13 @@ sv_print(FILE f[STATIC_CONST(1)], str_view const sv)
 }
 
 str_view
-sv_copy(size_t const str_sz, char const src_str[STATIC_CONST(1)])
+sv_copy(size_t const str_sz, char const PTR_GEQ(src_str, 1))
 {
     return sv_n(str_sz, src_str);
 }
 
 size_t
-sv_fill(size_t const dest_sz, char dest_buf[STATIC_CONST(dest_sz)],
+sv_fill(size_t const dest_sz, char PTR_CONST_GEQ(dest_buf, dest_sz),
         str_view const src)
 {
     if (!dest_sz || !src.s || !src.sz)
@@ -166,13 +169,13 @@ sv_size(str_view const sv)
 }
 
 size_t
-sv_strsize(char const str[STATIC_CONST(1)])
+sv_strsize(char const PTR_GEQ(str, 1))
 {
     return strlen(str) + 1;
 }
 
 size_t
-sv_minlen(char const str[STATIC_CONST(1)], size_t n)
+sv_minlen(char const PTR_GEQ(str, 1), size_t n)
 {
     return strnlen(str, n);
 }
@@ -194,7 +197,7 @@ sv_null(void)
 }
 
 void
-sv_swap(str_view a[STATIC_CONST(1)], str_view b[STATIC_CONST(1)])
+sv_swap(str_view PTR_GEQ(a, 1), str_view PTR_GEQ(b, 1))
 {
     if (a == b)
     {
@@ -230,7 +233,7 @@ sv_cmp(str_view const lhs, str_view const rhs)
 }
 
 sv_threeway_cmp
-sv_strcmp(str_view const lhs, char const rhs[STATIC_CONST(1)])
+sv_strcmp(str_view const lhs, char const PTR_GEQ(rhs, 1))
 {
     if (!lhs.s)
     {
@@ -252,7 +255,7 @@ sv_strcmp(str_view const lhs, char const rhs[STATIC_CONST(1)])
 }
 
 sv_threeway_cmp
-sv_strncmp(str_view const lhs, char const rhs[STATIC_CONST(1)], size_t const n)
+sv_strncmp(str_view const lhs, char const PTR_GEQ(rhs, 1), size_t const n)
 {
     if (!lhs.s)
     {
@@ -315,7 +318,7 @@ sv_end(str_view const sv)
 }
 
 char const *
-sv_next(char const c[STATIC(1)])
+sv_next(char const PTR_GEQ(c, 1))
 {
     return ++c;
 }
@@ -349,7 +352,7 @@ sv_rend(str_view const sv)
 }
 
 char const *
-sv_rnext(char const c[STATIC(1)])
+sv_rnext(char const PTR_GEQ(c, 1))
 {
     return --c;
 }
@@ -804,8 +807,8 @@ sv_rmemcmp(void const *const vl, void const *const vr, size_t n)
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strcspn(size_t const str_sz, char const str[STATIC_CONST(str_sz)],
-           size_t const set_sz, char const set[STATIC(set_sz)])
+sv_strcspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
+           size_t const set_sz, char const PTR_GEQ(set, set_sz))
 {
     if (!set_sz)
     {
@@ -837,8 +840,8 @@ sv_strcspn(size_t const str_sz, char const str[STATIC_CONST(str_sz)],
    end of a view until null is found. This way, string searches are
    efficient and only within the range specified. */
 static size_t
-sv_strspn(size_t const str_sz, char const str[STATIC_CONST(str_sz)],
-          size_t const set_sz, char const set[STATIC(set_sz)])
+sv_strspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
+          size_t const set_sz, char const PTR_GEQ(set, set_sz))
 {
     char const *a = str;
     size_t byteset[32 / sizeof(size_t)] = {0};
@@ -868,8 +871,9 @@ sv_strspn(size_t const str_sz, char const str[STATIC_CONST(str_sz)],
    hay length. Returns 0 based index position at which needle begins in
    hay if it can be found, otherwise the hay size is returned. */
 static size_t
-sv_strnstrn(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
-            ssize_t const needle_sz, char const needle[STATIC_CONST(needle_sz)])
+sv_strnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            ssize_t const needle_sz,
+            char const PTR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -903,9 +907,9 @@ sv_strnstrn(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
    the start of the reverse two-way algorithm for more. May unite if
    a clean way exists. */
 static size_t
-sv_rstrnstrn(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
+sv_rstrnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
              ssize_t const needle_sz,
-             char const needle[STATIC_CONST(needle_sz)])
+             char const PTR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
     {
@@ -961,8 +965,9 @@ sv_rstrnstrn(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
    an entire string. Returns the position at which needle begins if found
    and the size of the hay stack if not found. */
 static inline size_t
-sv_tw_match(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
-            ssize_t const needle_sz, char const needle[STATIC_CONST(needle_sz)])
+sv_tw_match(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            ssize_t const needle_sz,
+            char const PTR_CONST_GEQ(needle, needle_sz))
 {
     /* Preprocessing to get critical position and period distance. */
     struct sv_factorization const s = sv_maximal_suffix(needle_sz, needle);
@@ -981,8 +986,9 @@ sv_tw_match(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_memo(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
-            ssize_t const needle_sz, char const needle[STATIC_CONST(needle_sz)],
+sv_pos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            ssize_t const needle_sz,
+            char const PTR_CONST_GEQ(needle, needle_sz),
             ssize_t const period_dist, ssize_t const critical_pos)
 {
     ssize_t lpos = 0;
@@ -1023,9 +1029,9 @@ sv_pos_memo(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_normal(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
+sv_pos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
               ssize_t const needle_sz,
-              char const needle[STATIC_CONST(needle_sz)], ssize_t period_dist,
+              char const PTR_CONST_GEQ(needle, needle_sz), ssize_t period_dist,
               ssize_t const critical_pos)
 {
     period_dist
@@ -1065,7 +1071,7 @@ sv_pos_normal(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix(ssize_t const needle_sz,
-                  char const needle[STATIC_CONST(needle_sz)])
+                  char const PTR_CONST_GEQ(needle, needle_sz))
 {
     ssize_t suff_pos = -1;
     ssize_t period = 1;
@@ -1109,7 +1115,7 @@ sv_maximal_suffix(ssize_t const needle_sz,
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
 sv_maximal_suffix_rev(ssize_t const needle_sz,
-                      char const needle[STATIC_CONST(needle_sz)])
+                      char const PTR_CONST_GEQ(needle, needle_sz))
 {
     ssize_t suff_pos = -1;
     ssize_t period = 1;
@@ -1187,9 +1193,9 @@ sv_maximal_suffix_rev(ssize_t const needle_sz,
 /* Searches a string from right to left with a two-way algorithm. Returns
    the position of the start of the strig if found and string size if not. */
 static inline size_t
-sv_tw_rmatch(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
+sv_tw_rmatch(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
              ssize_t const needle_sz,
-             char const needle[STATIC_CONST(needle_sz)])
+             char const PTR_CONST_GEQ(needle, needle_sz))
 {
     struct sv_factorization const s = sv_rmaximal_suffix(needle_sz, needle);
     struct sv_factorization const r = sv_rmaximal_suffix_rev(needle_sz, needle);
@@ -1205,9 +1211,9 @@ sv_tw_rmatch(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
 }
 
 static size_t
-sv_rpos_memo(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
+sv_rpos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
              ssize_t const needle_sz,
-             char const needle[STATIC_CONST(needle_sz)],
+             char const PTR_CONST_GEQ(needle, needle_sz),
              ssize_t const period_dist, ssize_t const critical_pos)
 {
     ssize_t lpos = 0;
@@ -1249,9 +1255,9 @@ sv_rpos_memo(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
 }
 
 static size_t
-sv_rpos_normal(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
+sv_rpos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
                ssize_t const needle_sz,
-               char const needle[STATIC_CONST(needle_sz)], ssize_t period_dist,
+               char const PTR_CONST_GEQ(needle, needle_sz), ssize_t period_dist,
                ssize_t const critical_pos)
 {
     period_dist
@@ -1293,7 +1299,7 @@ sv_rpos_normal(ssize_t const hay_sz, char const hay[STATIC_CONST(hay_sz)],
 
 static inline struct sv_factorization
 sv_rmaximal_suffix(ssize_t const needle_sz,
-                   char const needle[STATIC_CONST(needle_sz)])
+                   char const PTR_CONST_GEQ(needle, needle_sz))
 {
     ssize_t suff_pos = -1;
     ssize_t period = 1;
@@ -1335,7 +1341,7 @@ sv_rmaximal_suffix(ssize_t const needle_sz,
 
 static inline struct sv_factorization
 sv_rmaximal_suffix_rev(ssize_t const needle_sz,
-                       char const needle[STATIC_CONST(needle_sz)])
+                       char const PTR_CONST_GEQ(needle, needle_sz))
 {
     ssize_t suff_pos = -1;
     ssize_t period = 1;
@@ -1387,7 +1393,7 @@ sv_rmaximal_suffix_rev(ssize_t const needle_sz,
    to left. Also having a reverse tokenizer is convenient and also relies
    on right to left brute force searches. */
 static inline size_t
-sv_strnchr(size_t n, char const s[STATIC(n)], char const c)
+sv_strnchr(size_t n, char const PTR_GEQ(s, n), char const c)
 {
     size_t i = 0;
     for (; n && *s != c; s++, --n, ++i)
@@ -1396,7 +1402,7 @@ sv_strnchr(size_t n, char const s[STATIC(n)], char const c)
 }
 
 static inline size_t
-sv_rstrnchr(size_t const n, char const s[STATIC_CONST(n)], char const c)
+sv_rstrnchr(size_t const n, char const PTR_CONST_GEQ(s, n), char const c)
 {
     char const *x = s + n - 1;
     size_t i = n;
@@ -1406,9 +1412,9 @@ sv_rstrnchr(size_t const n, char const s[STATIC_CONST(n)], char const c)
 }
 
 static inline size_t
-sv_twobyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_twobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                     size_t const n_sz,
-                    unsigned char const n[STATIC_CONST(n_sz)])
+                    unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     uint16_t nw = n[0] << 8 | n[1];
     uint16_t hw = h[0] << 8 | h[1];
@@ -1419,9 +1425,9 @@ sv_twobyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
 }
 
 static inline size_t
-sv_rtwobyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_rtwobyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                      size_t const n_sz,
-                     unsigned char const n[STATIC_CONST(n_sz)])
+                     unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 2;
     uint16_t nw = n[0] << 8 | n[1];
@@ -1436,9 +1442,9 @@ sv_rtwobyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
 }
 
 static inline size_t
-sv_threebyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_threebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                       size_t const n_sz,
-                      unsigned char const n[STATIC_CONST(n_sz)])
+                      unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8;
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8;
@@ -1449,9 +1455,9 @@ sv_threebyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
 }
 
 static inline size_t
-sv_rthreebyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_rthreebyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                        size_t const n_sz,
-                       unsigned char const n[STATIC_CONST(n_sz)])
+                       unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 3;
     uint32_t nw = (uint32_t)n[0] << 16 | n[1] << 8 | n[2];
@@ -1466,9 +1472,9 @@ sv_rthreebyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
 }
 
 static inline size_t
-sv_fourbyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_fourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                      size_t const n_sz,
-                     unsigned char const n[STATIC_CONST(n_sz)])
+                     unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];
     uint32_t hw = (uint32_t)h[0] << 24 | h[1] << 16 | h[2] << 8 | h[3];
@@ -1479,9 +1485,9 @@ sv_fourbyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
 }
 
 static inline size_t
-sv_rfourbyte_strnstrn(size_t const sz, unsigned char const h[STATIC(sz)],
+sv_rfourbyte_strnstrn(size_t const sz, unsigned char const PTR_GEQ(h, sz),
                       size_t const n_sz,
-                      unsigned char const n[STATIC_CONST(n_sz)])
+                      unsigned char const PTR_CONST_GEQ(n, n_sz))
 {
     h = h + sz - 4;
     uint32_t nw = (uint32_t)n[0] << 24 | n[1] << 16 | n[2] << 8 | n[3];

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -11,20 +11,15 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(_MSC_VER)
-#    include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#endif
-
 /* ========================   Type Definitions   =========================== */
 
 /* Return the factorization step of two-way search in precompute phase. */
 struct sv_factorization
 {
     /* Position in the needle at which (local period = period). */
-    ssize_t critical_pos;
+    int64_t critical_pos;
     /* A distance in the needle such that two letters always coincide. */
-    ssize_t period_dist;
+    int64_t period_dist;
 };
 
 /* Avoid giving the user a chance to dereference null as much as posssible
@@ -39,31 +34,31 @@ static size_t sv_after_find(str_view, str_view);
 static size_t sv_before_rfind(str_view, str_view);
 static size_t sv_min(size_t, size_t);
 static sv_threeway_cmp sv_char_cmp(char, char);
-static ssize_t sv_ssizet_max(ssize_t, ssize_t);
-static size_t sv_pos_memo(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
-                          ssize_t, ssize_t);
-static size_t sv_pos_normal(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                            ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
-                            ssize_t, ssize_t);
-static size_t sv_rpos_memo(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
-                           ssize_t, ssize_t);
-static size_t sv_rpos_normal(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                             ssize_t needle_sz, char const PTR_GEQ(, needle_sz),
-                             ssize_t, ssize_t);
-static size_t sv_tw_match(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
-static size_t sv_tw_rmatch(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static int64_t sv_ssizet_max(int64_t, int64_t);
+static size_t sv_pos_memo(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+                          int64_t, int64_t);
+static size_t sv_pos_normal(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                            int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+                            int64_t, int64_t);
+static size_t sv_rpos_memo(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+                           int64_t, int64_t);
+static size_t sv_rpos_normal(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                             int64_t needle_sz, char const PTR_GEQ(, needle_sz),
+                             int64_t, int64_t);
+static size_t sv_tw_match(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_tw_rmatch(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_maximal_suffix(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_maximal_suffix_rev(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_maximal_suffix_rev(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_rmaximal_suffix(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static struct sv_factorization
-sv_rmaximal_suffix_rev(ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+sv_rmaximal_suffix_rev(int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static size_t sv_twobyte_strnstrn(size_t hay_sz,
                                   unsigned char const PTR_GEQ(, hay_sz),
                                   size_t n_sz,
@@ -79,12 +74,12 @@ static size_t sv_strcspn(size_t str_sz, char const PTR_GEQ(, str_sz),
                          size_t set_sz, char const PTR_GEQ(, set_sz));
 static size_t sv_strspn(size_t str_sz, char const PTR_GEQ(, str_sz),
                         size_t set_sz, char const PTR_GEQ(, set_sz));
-static size_t sv_strnstrn(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                          ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_strnstrn(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                          int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static size_t sv_strnchr(size_t n, char const PTR_GEQ(, n), char);
 static size_t sv_rstrnchr(size_t n, char const PTR_GEQ(, n), char);
-static size_t sv_rstrnstrn(ssize_t hay_sz, char const PTR_GEQ(, hay_sz),
-                           ssize_t needle_sz, char const PTR_GEQ(, needle_sz));
+static size_t sv_rstrnstrn(int64_t hay_sz, char const PTR_GEQ(, hay_sz),
+                           int64_t needle_sz, char const PTR_GEQ(, needle_sz));
 static size_t sv_rtwobyte_strnstrn(size_t sz, unsigned char const PTR_GEQ(, sz),
                                    size_t n_sz,
                                    unsigned char const PTR_GEQ(, n_sz));
@@ -427,7 +422,7 @@ sv_next_tok(str_view const src, str_view const tok, str_view const delim)
         return (str_view){.s = src.s + src.sz, .sz = 0};
     }
     size_t const found
-        = sv_strnstrn((ssize_t)next.sz, next.s, (ssize_t)delim.sz, delim.s);
+        = sv_strnstrn((int64_t)next.sz, next.s, (int64_t)delim.sz, delim.s);
     return (str_view){.s = next.s, .sz = found};
 }
 
@@ -473,8 +468,8 @@ sv_rnext_tok(str_view const src, str_view const tok, str_view const delim)
     {
         return shorter;
     }
-    size_t start = sv_rstrnstrn((ssize_t)before_delim, shorter.s,
-                                (ssize_t)delim.sz, delim.s);
+    size_t start = sv_rstrnstrn((int64_t)before_delim, shorter.s,
+                                (int64_t)delim.sz, delim.s);
     if (start == before_delim)
     {
         return (str_view){.s = shorter.s, .sz = before_delim + 1};
@@ -567,7 +562,7 @@ sv_contains(str_view const hay, str_view const needle)
         return true;
     }
     return hay.sz
-           != sv_strnstrn((ssize_t)hay.sz, hay.s, (ssize_t)needle.sz, needle.s);
+           != sv_strnstrn((int64_t)hay.sz, hay.s, (int64_t)needle.sz, needle.s);
 }
 
 str_view
@@ -582,7 +577,7 @@ sv_match(str_view const hay, str_view const needle)
         return (str_view){.s = hay.s + hay.sz, .sz = 0};
     }
     size_t const found
-        = sv_strnstrn((ssize_t)hay.sz, hay.s, (ssize_t)needle.sz, needle.s);
+        = sv_strnstrn((int64_t)hay.sz, hay.s, (int64_t)needle.sz, needle.s);
     return found == hay.sz ? (str_view){.s = hay.s + hay.sz, .sz = 0}
                            : (str_view){.s = hay.s + found, .sz = needle.sz};
 }
@@ -599,7 +594,7 @@ sv_rmatch(str_view const hay, str_view const needle)
         return (str_view){.s = hay.s + hay.sz, .sz = 0};
     }
     size_t const found
-        = sv_rstrnstrn((ssize_t)hay.sz, hay.s, (ssize_t)needle.sz, needle.s);
+        = sv_rstrnstrn((int64_t)hay.sz, hay.s, (int64_t)needle.sz, needle.s);
     return found == hay.sz ? (str_view){.s = hay.s + hay.sz, .sz = 0}
                            : (str_view){.s = hay.s + found, .sz = needle.sz};
 }
@@ -612,8 +607,8 @@ sv_find(str_view const hay, size_t const pos, str_view const needle)
         return hay.sz;
     }
     return pos
-           + sv_strnstrn((ssize_t)(hay.sz - pos), hay.s + pos,
-                         (ssize_t)needle.sz, needle.s);
+           + sv_strnstrn((int64_t)(hay.sz - pos), hay.s + pos,
+                         (int64_t)needle.sz, needle.s);
 }
 
 size_t
@@ -628,7 +623,7 @@ sv_rfind(str_view const h, size_t pos, str_view const n)
         pos = h.sz - 1;
     }
     size_t const found
-        = sv_rstrnstrn((ssize_t)pos + 1, h.s, (ssize_t)n.sz, n.s);
+        = sv_rstrnstrn((int64_t)pos + 1, h.s, (int64_t)n.sz, n.s);
     return found == pos + 1 ? h.sz : found;
 }
 
@@ -763,8 +758,8 @@ sv_min(size_t const a, size_t const b)
     return a < b ? a : b;
 }
 
-static inline ssize_t
-sv_ssizet_max(ssize_t const a, ssize_t const b)
+static inline int64_t
+sv_ssizet_max(int64_t const a, int64_t const b)
 {
     return a > b ? a : b;
 }
@@ -871,8 +866,8 @@ sv_strspn(size_t const str_sz, char const PTR_CONST_GEQ(str, str_sz),
    hay length. Returns 0 based index position at which needle begins in
    hay if it can be found, otherwise the hay size is returned. */
 static size_t
-sv_strnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-            ssize_t const needle_sz,
+sv_strnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
             char const PTR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
@@ -907,8 +902,8 @@ sv_strnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
    the start of the reverse two-way algorithm for more. May unite if
    a clean way exists. */
 static size_t
-sv_rstrnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-             ssize_t const needle_sz,
+sv_rstrnstrn(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
              char const PTR_CONST_GEQ(needle, needle_sz))
 {
     if (!hay_sz || !needle_sz || needle_sz > hay_sz)
@@ -965,8 +960,8 @@ sv_rstrnstrn(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
    an entire string. Returns the position at which needle begins if found
    and the size of the hay stack if not found. */
 static inline size_t
-sv_tw_match(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-            ssize_t const needle_sz,
+sv_tw_match(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
             char const PTR_CONST_GEQ(needle, needle_sz))
 {
     /* Preprocessing to get critical position and period distance. */
@@ -986,15 +981,15 @@ sv_tw_match(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-            ssize_t const needle_sz,
+sv_pos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+            int64_t const needle_sz,
             char const PTR_CONST_GEQ(needle, needle_sz),
-            ssize_t const period_dist, ssize_t const critical_pos)
+            int64_t const period_dist, int64_t const critical_pos)
 {
-    ssize_t lpos = 0;
-    ssize_t rpos = 0;
+    int64_t lpos = 0;
+    int64_t rpos = 0;
     /* Eliminate worst case quadratic time complexity with memoization. */
-    ssize_t memoize_shift = -1;
+    int64_t memoize_shift = -1;
     while (lpos <= hay_sz - needle_sz)
     {
         rpos = sv_ssizet_max(critical_pos, memoize_shift) + 1;
@@ -1029,15 +1024,15 @@ sv_pos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* Two Way string matching algorithm adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static size_t
-sv_pos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-              ssize_t const needle_sz,
-              char const PTR_CONST_GEQ(needle, needle_sz), ssize_t period_dist,
-              ssize_t const critical_pos)
+sv_pos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+              int64_t const needle_sz,
+              char const PTR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+              int64_t const critical_pos)
 {
     period_dist
         = sv_ssizet_max(critical_pos + 1, needle_sz - critical_pos - 1) + 1;
-    ssize_t lpos = 0;
-    ssize_t rpos = 0;
+    int64_t lpos = 0;
+    int64_t rpos = 0;
     while (lpos <= hay_sz - needle_sz)
     {
         rpos = critical_pos + 1;
@@ -1070,13 +1065,13 @@ sv_pos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* Computing of the maximal suffix. Adapted from ESMAJ.
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
-sv_maximal_suffix(ssize_t const needle_sz,
+sv_maximal_suffix(int64_t const needle_sz,
                   char const PTR_CONST_GEQ(needle, needle_sz))
 {
-    ssize_t suff_pos = -1;
-    ssize_t period = 1;
-    ssize_t last_rest = 0;
-    ssize_t rest = 1;
+    int64_t suff_pos = -1;
+    int64_t period = 1;
+    int64_t last_rest = 0;
+    int64_t rest = 1;
     while (last_rest + rest < needle_sz)
     {
         switch (sv_char_cmp(needle[last_rest + rest], needle[suff_pos + rest]))
@@ -1114,13 +1109,13 @@ sv_maximal_suffix(ssize_t const needle_sz,
    adapted from ESMAJ
    http://igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 */
 static inline struct sv_factorization
-sv_maximal_suffix_rev(ssize_t const needle_sz,
+sv_maximal_suffix_rev(int64_t const needle_sz,
                       char const PTR_CONST_GEQ(needle, needle_sz))
 {
-    ssize_t suff_pos = -1;
-    ssize_t period = 1;
-    ssize_t last_rest = 0;
-    ssize_t rest = 1;
+    int64_t suff_pos = -1;
+    int64_t period = 1;
+    int64_t last_rest = 0;
+    int64_t rest = 1;
     while (last_rest + rest < needle_sz)
     {
         switch (sv_char_cmp(needle[last_rest + rest], needle[suff_pos + rest]))
@@ -1163,12 +1158,12 @@ sv_maximal_suffix_rev(ssize_t const needle_sz,
    these functions into one with the following formula
    (using the suffix calculation as an example):
 
-        ssize_t suff_pos = -1;
-        ssize_t period = 1;
-        ssize_t last_rest = 0;
-        ssize_t rest = 1;
-        ssize_t negate_sz = 0;
-        ssize_t negate_one = 0;
+        int64_t suff_pos = -1;
+        int64_t period = 1;
+        int64_t last_rest = 0;
+        int64_t rest = 1;
+        int64_t negate_sz = 0;
+        int64_t negate_one = 0;
         if (direction == FORWARD)
         {
             negate_sz = needle_sz;
@@ -1193,8 +1188,8 @@ sv_maximal_suffix_rev(ssize_t const needle_sz,
 /* Searches a string from right to left with a two-way algorithm. Returns
    the position of the start of the strig if found and string size if not. */
 static inline size_t
-sv_tw_rmatch(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-             ssize_t const needle_sz,
+sv_tw_rmatch(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
              char const PTR_CONST_GEQ(needle, needle_sz))
 {
     struct sv_factorization const s = sv_rmaximal_suffix(needle_sz, needle);
@@ -1211,14 +1206,14 @@ sv_tw_rmatch(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-             ssize_t const needle_sz,
+sv_rpos_memo(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+             int64_t const needle_sz,
              char const PTR_CONST_GEQ(needle, needle_sz),
-             ssize_t const period_dist, ssize_t const critical_pos)
+             int64_t const period_dist, int64_t const critical_pos)
 {
-    ssize_t lpos = 0;
-    ssize_t rpos = 0;
-    ssize_t memoize_shift = -1;
+    int64_t lpos = 0;
+    int64_t rpos = 0;
+    int64_t memoize_shift = -1;
     while (lpos <= hay_sz - needle_sz)
     {
         rpos = sv_ssizet_max(critical_pos, memoize_shift) + 1;
@@ -1255,15 +1250,15 @@ sv_rpos_memo(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 }
 
 static size_t
-sv_rpos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
-               ssize_t const needle_sz,
-               char const PTR_CONST_GEQ(needle, needle_sz), ssize_t period_dist,
-               ssize_t const critical_pos)
+sv_rpos_normal(int64_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
+               int64_t const needle_sz,
+               char const PTR_CONST_GEQ(needle, needle_sz), int64_t period_dist,
+               int64_t const critical_pos)
 {
     period_dist
         = sv_ssizet_max(critical_pos + 1, needle_sz - critical_pos - 1) + 1;
-    ssize_t lpos = 0;
-    ssize_t rpos = 0;
+    int64_t lpos = 0;
+    int64_t rpos = 0;
     while (lpos <= hay_sz - needle_sz)
     {
         rpos = critical_pos + 1;
@@ -1298,13 +1293,13 @@ sv_rpos_normal(ssize_t const hay_sz, char const PTR_CONST_GEQ(hay, hay_sz),
 /* NOLINTEND(*easily-swappable*) */
 
 static inline struct sv_factorization
-sv_rmaximal_suffix(ssize_t const needle_sz,
+sv_rmaximal_suffix(int64_t const needle_sz,
                    char const PTR_CONST_GEQ(needle, needle_sz))
 {
-    ssize_t suff_pos = -1;
-    ssize_t period = 1;
-    ssize_t last_rest = 0;
-    ssize_t rest = 1;
+    int64_t suff_pos = -1;
+    int64_t period = 1;
+    int64_t last_rest = 0;
+    int64_t rest = 1;
     while (last_rest + rest < needle_sz)
     {
         switch (sv_char_cmp(needle[needle_sz - (last_rest + rest) - 1],
@@ -1340,13 +1335,13 @@ sv_rmaximal_suffix(ssize_t const needle_sz,
 }
 
 static inline struct sv_factorization
-sv_rmaximal_suffix_rev(ssize_t const needle_sz,
+sv_rmaximal_suffix_rev(int64_t const needle_sz,
                        char const PTR_CONST_GEQ(needle, needle_sz))
 {
-    ssize_t suff_pos = -1;
-    ssize_t period = 1;
-    ssize_t last_rest = 0;
-    ssize_t rest = 1;
+    int64_t suff_pos = -1;
+    int64_t period = 1;
+    int64_t last_rest = 0;
+    int64_t rest = 1;
     while (last_rest + rest < needle_sz)
     {
         switch (sv_char_cmp(needle[needle_sz - (last_rest + rest) - 1],

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -20,11 +20,6 @@
 #        else
 #            define ATTRIB_CONST /**/
 #        endif
-#        if __has_attribute(nonnull)
-#            define ATTRIB_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
-#        else
-#            define ATTRIB_NONNULL(...) /**/
-#        endif
 #        if __has_attribute(null_terminated_string_arg)
 #            define ATTRIB_NULLTERM(...)                                       \
                 __attribute__((null_terminated_string_arg(__VA_ARGS__)))
@@ -34,7 +29,6 @@
 #    else
 #        define ATTRIB_PURE          /**/
 #        define ATTRIB_CONST         /**/
-#        define ATTRIB_NONNULL(...)  /**/
 #        define ATTRIB_NULLTERM(...) /**/
 #    endif
 /* A helper macro to enforce only string literals for the SV constructor
@@ -44,7 +38,6 @@
 #else
 #    define ATTRIB_PURE          /**/
 #    define ATTRIB_CONST         /**/
-#    define ATTRIB_NONNULL(...)  /**/
 #    define ATTRIB_NULLTERM(...) /**/
 
 /* MSVC does not allow strong enforcement of string literals to the SV
@@ -111,14 +104,12 @@ typedef enum
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */
-SV_API str_view sv(char const *str) ATTRIB_NONNULL(1)
-    ATTRIB_NULLTERM(1) ATTRIB_PURE;
+SV_API str_view sv(char const *str) ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a sequence of valid n bytes
    or string length, whichever comes first. The resulting str_view may
    or may not be null terminated at the index of its size. */
-SV_API str_view sv_n(size_t n, char const *str) ATTRIB_NONNULL(2)
-    ATTRIB_NULLTERM(2) ATTRIB_PURE;
+SV_API str_view sv_n(size_t n, char const *str) ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a NULL TERMINATED string
    broken on the first ocurrence of delimeter if found or null
@@ -126,23 +117,21 @@ SV_API str_view sv_n(size_t n, char const *str) ATTRIB_NONNULL(2)
    skip the delimeter if that delimeter starts the string. This is similar
    to the tokenizing function in the iteration section. */
 SV_API str_view sv_delim(char const *str, char const *delim)
-    ATTRIB_NONNULL(1, 2) ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
+    ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
 
 /* Returns the bytes of the string pointer to, null terminator included. */
-SV_API size_t sv_strsize(char const *str) ATTRIB_NONNULL(1)
-    ATTRIB_NULLTERM(1) ATTRIB_PURE;
+SV_API size_t sv_strsize(char const *str) ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Copies the max of str_sz or src_str length into a view, whichever
    ends first. This is the same as sv_n. */
-SV_API str_view sv_copy(size_t str_sz, char const *src_str) ATTRIB_NONNULL(2)
+SV_API str_view sv_copy(size_t str_sz, char const *src_str)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Fills the destination buffer with the minimum between
    destination size and source view size, null terminating
    the string. This may cut off src data if dest_sz < src.sz.
    Returns how many bytes were written to the buffer. */
-SV_API size_t sv_fill(size_t dest_sz, char *dest_buf, str_view src)
-    ATTRIB_NONNULL(2);
+SV_API size_t sv_fill(size_t dest_sz, char *dest_buf, str_view src);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and a c-string.
@@ -153,7 +142,7 @@ SV_API size_t sv_fill(size_t dest_sz, char *dest_buf, str_view src)
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
 SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const *rhs)
-    ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
+    ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and the first n bytes (inclusive) of str
@@ -165,22 +154,21 @@ SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const *rhs)
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
 SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const *rhs, size_t n)
-    ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
+    ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the minimum between the string size vs n bytes. */
-SV_API size_t sv_minlen(char const *str, size_t n) ATTRIB_NONNULL(1)
+SV_API size_t sv_minlen(char const *str, size_t n)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the pointer from its previous position. If NULL is provided
    sv_null() is returned. */
-SV_API char const *sv_next(char const *c) ATTRIB_NONNULL(1)
-    ATTRIB_NULLTERM(1) ATTRIB_PURE;
+SV_API char const *sv_next(char const *c) ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the iterator to the next character in the str_view
    being iterated through in reverse. It is undefined behavior
    to change the str_view one is iterating through during
    iteration. If the char pointer is null, sv_null() is returned. */
-SV_API char const *sv_rnext(char const *c) ATTRIB_NONNULL(1) ATTRIB_PURE;
+SV_API char const *sv_rnext(char const *c) ATTRIB_PURE;
 
 /* Creates the substring from position pos for count length. The count is
    the minimum value between count and (length - pos). If an invalid

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -439,6 +439,6 @@ SV_API size_t sv_find_last_not_of(str_view hay, str_view set) ATTRIB_PURE;
 /*============================  Printing  ==================================*/
 
 /* Writes all characters in str_view to specified file such as stdout. */
-SV_API void sv_print(FILE *f, str_view sv) ATTRIB_NONNULL(1);
+SV_API void sv_print(FILE *f, str_view sv);
 
 #endif /* STR_VIEW */

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -37,22 +37,6 @@
 #        define ATTRIB_NONNULL(...)  /**/
 #        define ATTRIB_NULLTERM(...) /**/
 #    endif
-/* Clang and GCC support static array parameter declarations while
-   MSVC does not. This is how to solve the differing declaration
-   signature requirements. */
-
-/* A static array parameter declaration helper. Function parameters
-   may specify an array of a type of at least SIZE elements large,
-   allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, ARR_GEQ(arr, size))`. */
-#    define ARR_GEQ(str, size) str[static(size)]
-/* A static array parameter declaration helper. Function parameters
-   may specify an array of a type of at least SIZE elements large,
-   allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, int arr[STATIC_CONST(size)])`.
-   This declarations adds the additional constraint that the pointer
-   to the begginning of the array of types will not move. */
-#    define ARR_CONST_GEQ(str, size) str[static const(size)]
 /* A helper macro to enforce only string literals for the SV constructor
    macro. GCC and Clang allow this syntax to create more errors when bad
    input is provided to the str_view SV constructor.*/
@@ -62,18 +46,7 @@
 #    define ATTRIB_CONST         /**/
 #    define ATTRIB_NONNULL(...)  /**/
 #    define ATTRIB_NULLTERM(...) /**/
-/* MSVC does not support a static array parameter declaration
-   so the best it can do is promise arrays of at least one
-   element, unlike more dynamic clang and GCC capabilities. */
 
-/* Dummy macro for MSVC compatibility. Specifies a function parameter shall
-   have at least one element. Compiler warnings may differ from GCC/Clang. */
-#    define ARR_GEQ(str, size) *str
-/* Dummy macro for MSVC compatibility. Specifies a function parameter shall
-   have at least one element. MSVC does not allow specification of a const
-   pointer to the begginning of an array function parameter when using array
-   size parameter syntax. Compiler warnings may differ from GCC/Clang. */
-#    define ARR_CONST_GEQ(str, size) *const str
 /* MSVC does not allow strong enforcement of string literals to the SV
    str_view constructor. This is a dummy wrapper for compatibility. */
 #    define STR_LITERAL(str) str
@@ -138,13 +111,13 @@ typedef enum
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */
-SV_API str_view sv(char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(1)
+SV_API str_view sv(char const *str) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a sequence of valid n bytes
    or string length, whichever comes first. The resulting str_view may
    or may not be null terminated at the index of its size. */
-SV_API str_view sv_n(size_t n, char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(2)
+SV_API str_view sv_n(size_t n, char const *str) ATTRIB_NONNULL(2)
     ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a NULL TERMINATED string
@@ -152,25 +125,24 @@ SV_API str_view sv_n(size_t n, char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(2)
    terminator if delim cannot be found. This constructor will also
    skip the delimeter if that delimeter starts the string. This is similar
    to the tokenizing function in the iteration section. */
-SV_API str_view sv_delim(char const ARR_GEQ(str, 1),
-                         char const ARR_GEQ(delim, 1)) ATTRIB_NONNULL(1, 2)
-    ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
+SV_API str_view sv_delim(char const *str, char const *delim)
+    ATTRIB_NONNULL(1, 2) ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
 
 /* Returns the bytes of the string pointer to, null terminator included. */
-SV_API size_t sv_strsize(char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(1)
+SV_API size_t sv_strsize(char const *str) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Copies the max of str_sz or src_str length into a view, whichever
    ends first. This is the same as sv_n. */
-SV_API str_view sv_copy(size_t str_sz, char const ARR_GEQ(src_str, 1))
-    ATTRIB_NONNULL(2) ATTRIB_NULLTERM(1) ATTRIB_PURE;
+SV_API str_view sv_copy(size_t str_sz, char const *src_str) ATTRIB_NONNULL(2)
+    ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Fills the destination buffer with the minimum between
    destination size and source view size, null terminating
    the string. This may cut off src data if dest_sz < src.sz.
    Returns how many bytes were written to the buffer. */
-SV_API size_t sv_fill(size_t dest_sz, char ARR_GEQ(dest_buf, dest_sz),
-                      str_view src) ATTRIB_NONNULL(2);
+SV_API size_t sv_fill(size_t dest_sz, char *dest_buf, str_view src)
+    ATTRIB_NONNULL(2);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and a c-string.
@@ -180,7 +152,7 @@ SV_API size_t sv_fill(size_t dest_sz, char ARR_GEQ(dest_buf, dest_sz),
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const ARR_GEQ(rhs, 1))
+SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const *rhs)
     ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -192,25 +164,23 @@ SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const ARR_GEQ(rhs, 1))
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const ARR_GEQ(rhs, 1),
-                                  size_t n) ATTRIB_NONNULL(2)
-    ATTRIB_NULLTERM(2) ATTRIB_PURE;
+SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const *rhs, size_t n)
+    ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the minimum between the string size vs n bytes. */
-SV_API size_t sv_minlen(char const ARR_GEQ(str, 1), size_t n) ATTRIB_NONNULL(1)
+SV_API size_t sv_minlen(char const *str, size_t n) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the pointer from its previous position. If NULL is provided
    sv_null() is returned. */
-SV_API char const *sv_next(char const ARR_GEQ(c, 1)) ATTRIB_NONNULL(1)
+SV_API char const *sv_next(char const *c) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the iterator to the next character in the str_view
    being iterated through in reverse. It is undefined behavior
    to change the str_view one is iterating through during
    iteration. If the char pointer is null, sv_null() is returned. */
-SV_API char const *sv_rnext(char const ARR_GEQ(c, 1))
-    ATTRIB_NONNULL(1) ATTRIB_PURE;
+SV_API char const *sv_rnext(char const *c) ATTRIB_NONNULL(1) ATTRIB_PURE;
 
 /* Creates the substring from position pos for count length. The count is
    the minimum value between count and (length - pos). If an invalid

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -44,15 +44,15 @@
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, PTR_GEQ(arr, size))`. */
-#    define PTR_GEQ(str, size) str[static(size)]
+   a parameter such as `void func(int size, ARR_GEQ(arr, size))`. */
+#    define ARR_GEQ(str, size) str[static(size)]
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
    a parameter such as `void func(int size, int arr[STATIC_CONST(size)])`.
    This declarations adds the additional constraint that the pointer
    to the begginning of the array of types will not move. */
-#    define PTR_CONST_GEQ(str, size) str[static const(size)]
+#    define ARR_CONST_GEQ(str, size) str[static const(size)]
 /* A helper macro to enforce only string literals for the SV constructor
    macro. GCC and Clang allow this syntax to create more errors when bad
    input is provided to the str_view SV constructor.*/
@@ -68,12 +68,12 @@
 
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. Compiler warnings may differ from GCC/Clang. */
-#    define PTR_GEQ(str, size) *str
+#    define ARR_GEQ(str, size) *str
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. MSVC does not allow specification of a const
    pointer to the begginning of an array function parameter when using array
    size parameter syntax. Compiler warnings may differ from GCC/Clang. */
-#    define PTR_CONST_GEQ(str, size) *const str
+#    define ARR_CONST_GEQ(str, size) *const str
 /* MSVC does not allow strong enforcement of string literals to the SV
    str_view constructor. This is a dummy wrapper for compatibility. */
 #    define STR_LITERAL(str) str
@@ -138,13 +138,13 @@ typedef enum
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */
-SV_API str_view sv(char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(1)
+SV_API str_view sv(char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a sequence of valid n bytes
    or string length, whichever comes first. The resulting str_view may
    or may not be null terminated at the index of its size. */
-SV_API str_view sv_n(size_t n, char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(2)
+SV_API str_view sv_n(size_t n, char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(2)
     ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a NULL TERMINATED string
@@ -152,24 +152,24 @@ SV_API str_view sv_n(size_t n, char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(2)
    terminator if delim cannot be found. This constructor will also
    skip the delimeter if that delimeter starts the string. This is similar
    to the tokenizing function in the iteration section. */
-SV_API str_view sv_delim(char const PTR_GEQ(str, 1),
-                         char const PTR_GEQ(delim, 1)) ATTRIB_NONNULL(1, 2)
+SV_API str_view sv_delim(char const ARR_GEQ(str, 1),
+                         char const ARR_GEQ(delim, 1)) ATTRIB_NONNULL(1, 2)
     ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
 
 /* Returns the bytes of the string pointer to, null terminator included. */
-SV_API size_t sv_strsize(char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(1)
+SV_API size_t sv_strsize(char const ARR_GEQ(str, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Copies the max of str_sz or src_str length into a view, whichever
    ends first. This is the same as sv_n. */
-SV_API str_view sv_copy(size_t str_sz, char const PTR_GEQ(src_str, 1))
+SV_API str_view sv_copy(size_t str_sz, char const ARR_GEQ(src_str, 1))
     ATTRIB_NONNULL(2) ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Fills the destination buffer with the minimum between
    destination size and source view size, null terminating
    the string. This may cut off src data if dest_sz < src.sz.
    Returns how many bytes were written to the buffer. */
-SV_API size_t sv_fill(size_t dest_sz, char PTR_GEQ(dest_buf, dest_sz),
+SV_API size_t sv_fill(size_t dest_sz, char ARR_GEQ(dest_buf, dest_sz),
                       str_view src) ATTRIB_NONNULL(2);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -180,7 +180,7 @@ SV_API size_t sv_fill(size_t dest_sz, char PTR_GEQ(dest_buf, dest_sz),
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const PTR_GEQ(rhs, 1))
+SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const ARR_GEQ(rhs, 1))
     ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -192,24 +192,24 @@ SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const PTR_GEQ(rhs, 1))
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const PTR_GEQ(rhs, 1),
+SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const ARR_GEQ(rhs, 1),
                                   size_t n) ATTRIB_NONNULL(2)
     ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the minimum between the string size vs n bytes. */
-SV_API size_t sv_minlen(char const PTR_GEQ(str, 1), size_t n) ATTRIB_NONNULL(1)
+SV_API size_t sv_minlen(char const ARR_GEQ(str, 1), size_t n) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the pointer from its previous position. If NULL is provided
    sv_null() is returned. */
-SV_API char const *sv_next(char const PTR_GEQ(c, 1)) ATTRIB_NONNULL(1)
+SV_API char const *sv_next(char const ARR_GEQ(c, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the iterator to the next character in the str_view
    being iterated through in reverse. It is undefined behavior
    to change the str_view one is iterating through during
    iteration. If the char pointer is null, sv_null() is returned. */
-SV_API char const *sv_rnext(char const PTR_GEQ(c, 1))
+SV_API char const *sv_rnext(char const ARR_GEQ(c, 1))
     ATTRIB_NONNULL(1) ATTRIB_PURE;
 
 /* Creates the substring from position pos for count length. The count is
@@ -249,8 +249,7 @@ SV_API size_t sv_size(str_view sv) ATTRIB_CONST;
 
 /* Swaps the contents of a and b. Becuase these are read only views
    only pointers and sizes are exchanged. */
-SV_API void sv_swap(str_view PTR_GEQ(a, 1), str_view PTR_GEQ(b, 1))
-    ATTRIB_NONNULL(1, 2);
+SV_API void sv_swap(str_view *a, str_view *b);
 
 /* Returns a str_view of the entirety of the underlying string, starting
    at the current view pointer position. This guarantees that the str_view

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -44,15 +44,15 @@
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
-   a parameter such as `void func(int size, int arr[STATIC(size)])`. */
-#    define PTR_GEQ(str, size) str[static size]
+   a parameter such as `void func(int size, PTR_GEQ(arr, size))`. */
+#    define PTR_GEQ(str, size) str[static(size)]
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
    a parameter such as `void func(int size, int arr[STATIC_CONST(size)])`.
    This declarations adds the additional constraint that the pointer
    to the begginning of the array of types will not move. */
-#    define PTR_CONST_GEQ(str, size) str[static const size]
+#    define PTR_CONST_GEQ(str, size) str[static const(size)]
 /* A helper macro to enforce only string literals for the SV constructor
    macro. GCC and Clang allow this syntax to create more errors when bad
    input is provided to the str_view SV constructor.*/
@@ -134,7 +134,7 @@ typedef enum
        {}
 
    However saving the str_view in a constant may be more convenient. */
-#define SV(STR) ((str_view){STR_LITERAL(STR), sizeof(STR) - 1})
+#define SV(str) ((str_view){STR_LITERAL(str), sizeof(str) - 1})
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -45,18 +45,18 @@
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
    a parameter such as `void func(int size, int arr[STATIC(size)])`. */
-#    define STATIC(SIZE) static SIZE
+#    define PTR_GEQ(str, size) str[static size]
 /* A static array parameter declaration helper. Function parameters
    may specify an array of a type of at least SIZE elements large,
    allowing compiler optimizations and safety errors. Specify
    a parameter such as `void func(int size, int arr[STATIC_CONST(size)])`.
    This declarations adds the additional constraint that the pointer
    to the begginning of the array of types will not move. */
-#    define STATIC_CONST(SIZE) static const SIZE
+#    define PTR_CONST_GEQ(str, size) str[static const size]
 /* A helper macro to enforce only string literals for the SV constructor
    macro. GCC and Clang allow this syntax to create more errors when bad
    input is provided to the str_view SV constructor.*/
-#    define STR_LITERAL(STR) "" STR ""
+#    define STR_LITERAL(str) "" str ""
 #else
 #    define ATTRIB_PURE          /**/
 #    define ATTRIB_CONST         /**/
@@ -68,18 +68,18 @@
 
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. Compiler warnings may differ from GCC/Clang. */
-#    define STATIC(SIZE) 1
+#    define PTR_GEQ(str, size) *str
 /* Dummy macro for MSVC compatibility. Specifies a function parameter shall
    have at least one element. MSVC does not allow specification of a const
    pointer to the begginning of an array function parameter when using array
    size parameter syntax. Compiler warnings may differ from GCC/Clang. */
-#    define STATIC_CONST(SIZE) 1
+#    define PTR_CONST_GEQ(str, size) *const str
 /* MSVC does not allow strong enforcement of string literals to the SV
    str_view constructor. This is a dummy wrapper for compatibility. */
-#    define STR_LITERAL(STR) STR
+#    define STR_LITERAL(str) str
 #endif /* __GNUC__ || __clang__ || __INTEL_LLVM_COMPILER */
 
-#if defined(_MSVC_VER)
+#if defined(_MSVC_VER) || defined(_WIN32) || defined(_WIN64)
 #    if defined(SV_BUILD_DLL)
 #        define SV_API __declspec(dllexport)
 #    elif defined(SV_CONSUME_DLL)
@@ -138,13 +138,13 @@ typedef enum
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */
-SV_API str_view sv(char const str[STATIC(1)]) ATTRIB_NONNULL(1)
+SV_API str_view sv(char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a sequence of valid n bytes
    or string length, whichever comes first. The resulting str_view may
    or may not be null terminated at the index of its size. */
-SV_API str_view sv_n(size_t n, char const str[STATIC(1)]) ATTRIB_NONNULL(2)
+SV_API str_view sv_n(size_t n, char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(2)
     ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Constructs and returns a string view from a NULL TERMINATED string
@@ -152,23 +152,24 @@ SV_API str_view sv_n(size_t n, char const str[STATIC(1)]) ATTRIB_NONNULL(2)
    terminator if delim cannot be found. This constructor will also
    skip the delimeter if that delimeter starts the string. This is similar
    to the tokenizing function in the iteration section. */
-SV_API str_view sv_delim(char const str[STATIC(1)], char const delim[STATIC(1)])
-    ATTRIB_NONNULL(1, 2) ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
+SV_API str_view sv_delim(char const PTR_GEQ(str, 1),
+                         char const PTR_GEQ(delim, 1)) ATTRIB_NONNULL(1, 2)
+    ATTRIB_NULLTERM(1, 2) ATTRIB_PURE;
 
 /* Returns the bytes of the string pointer to, null terminator included. */
-SV_API size_t sv_strsize(char const str[STATIC(1)]) ATTRIB_NONNULL(1)
+SV_API size_t sv_strsize(char const PTR_GEQ(str, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Copies the max of str_sz or src_str length into a view, whichever
    ends first. This is the same as sv_n. */
-SV_API str_view sv_copy(size_t str_sz, char const src_str[STATIC(1)])
+SV_API str_view sv_copy(size_t str_sz, char const PTR_GEQ(src_str, 1))
     ATTRIB_NONNULL(2) ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Fills the destination buffer with the minimum between
    destination size and source view size, null terminating
    the string. This may cut off src data if dest_sz < src.sz.
    Returns how many bytes were written to the buffer. */
-SV_API size_t sv_fill(size_t dest_sz, char dest_buf[STATIC(dest_sz)],
+SV_API size_t sv_fill(size_t dest_sz, char PTR_GEQ(dest_buf, dest_sz),
                       str_view src) ATTRIB_NONNULL(2);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -179,7 +180,7 @@ SV_API size_t sv_fill(size_t dest_sz, char dest_buf[STATIC(dest_sz)],
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const rhs[STATIC(1)])
+SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const PTR_GEQ(rhs, 1))
     ATTRIB_NONNULL(2) ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -191,24 +192,24 @@ SV_API sv_threeway_cmp sv_strcmp(str_view lhs, char const rhs[STATIC(1)])
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const rhs[STATIC(1)],
+SV_API sv_threeway_cmp sv_strncmp(str_view lhs, char const PTR_GEQ(rhs, 1),
                                   size_t n) ATTRIB_NONNULL(2)
     ATTRIB_NULLTERM(2) ATTRIB_PURE;
 
 /* Returns the minimum between the string size vs n bytes. */
-SV_API size_t sv_minlen(char const str[STATIC(1)], size_t n) ATTRIB_NONNULL(1)
+SV_API size_t sv_minlen(char const PTR_GEQ(str, 1), size_t n) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the pointer from its previous position. If NULL is provided
    sv_null() is returned. */
-SV_API char const *sv_next(char const c[STATIC(1)]) ATTRIB_NONNULL(1)
+SV_API char const *sv_next(char const PTR_GEQ(c, 1)) ATTRIB_NONNULL(1)
     ATTRIB_NULLTERM(1) ATTRIB_PURE;
 
 /* Advances the iterator to the next character in the str_view
    being iterated through in reverse. It is undefined behavior
    to change the str_view one is iterating through during
    iteration. If the char pointer is null, sv_null() is returned. */
-SV_API char const *sv_rnext(char const c[STATIC(1)])
+SV_API char const *sv_rnext(char const PTR_GEQ(c, 1))
     ATTRIB_NONNULL(1) ATTRIB_PURE;
 
 /* Creates the substring from position pos for count length. The count is
@@ -248,7 +249,7 @@ SV_API size_t sv_size(str_view sv) ATTRIB_CONST;
 
 /* Swaps the contents of a and b. Becuase these are read only views
    only pointers and sizes are exchanged. */
-SV_API void sv_swap(str_view a[STATIC(1)], str_view b[STATIC(1)])
+SV_API void sv_swap(str_view PTR_GEQ(a, 1), str_view PTR_GEQ(b, 1))
     ATTRIB_NONNULL(1, 2);
 
 /* Returns a str_view of the entirety of the underlying string, starting
@@ -439,6 +440,6 @@ SV_API size_t sv_find_last_not_of(str_view hay, str_view set) ATTRIB_PURE;
 /*============================  Printing  ==================================*/
 
 /* Writes all characters in str_view to specified file such as stdout. */
-SV_API void sv_print(FILE f[STATIC(1)], str_view sv) ATTRIB_NONNULL(1);
+SV_API void sv_print(FILE *f, str_view sv) ATTRIB_NONNULL(1);
 
 #endif /* STR_VIEW */

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -39,7 +39,6 @@
 #    define ATTRIB_PURE          /**/
 #    define ATTRIB_CONST         /**/
 #    define ATTRIB_NULLTERM(...) /**/
-
 /* MSVC does not allow strong enforcement of string literals to the SV
    str_view constructor. This is a dummy wrapper for compatibility. */
 #    define STR_LITERAL(str) str
@@ -94,9 +93,9 @@ typedef enum
    One can even use this in code when string literals are used rather than
    saved constants to avoid errors in str_view constructions.
 
-       for (str_view cur = sv_begin_tok(ref, SV(" "));
-            !sv_end_tok(ref_view, cur);
-            cur = sv_next_tok(ref_view, cur, SV(" "))
+       for (str_view cur = sv_begin_tok(src, SV(" "));
+            !sv_end_tok(src, cur);
+            cur = sv_next_tok(src, cur, SV(" "))
        {}
 
    However saving the str_view in a constant may be more convenient. */


### PR DESCRIPTION
It seems some windows compilers on vcpkg ci still have trouble with any array syntax in a function parameter.