### PR TITLE
add assert and segfault signal catching in test harness

### DIFF
--- a/tests/run_tests.c
+++ b/tests/run_tests.c
@@ -117,7 +117,8 @@ run_test_process(struct path_bin pb)
         (void)fprintf(stderr, "Error running test: %s\n", sv_begin(pb.bin));
         return ERROR;
     }
-    if (WIFEXITED(status) && WEXITSTATUS(status) == FAIL)
+    if (WIFSIGNALED(status)
+        || (WIFEXITED(status) && WEXITSTATUS(status) == FAIL))
     {
         return FAIL;
     }


### PR DESCRIPTION
if an assert fails in a test or a segfault occurs the test harness may have allowed such a failure to be silent and the test would still report a pass. This should fix that problem.