### PR TITLE
fix issues highlighted by sanitizers and add new configs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,6 +62,26 @@
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_C_FLAGS": "-Wall -Wextra -Wfloat-equal -Wtype-limits -Wpointer-arith -Wshadow -Winit-self -fno-diagnostics-show-option -Wno-pointer-bool-conversion"
             }
+        },
+        {
+            "name": "gcc-debsan",
+            "inherits": "default-deb",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_C_FLAGS": "-g3 -Wall -Wextra -Wfloat-equal -Wtype-limits -Wpointer-arith -Wshadow -Winit-self -fno-diagnostics-show-option -fanalyzer -fsanitize=address,leak,undefined",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,leak,undefined"
+            }
+        },
+        {
+            "name": "gcc-relsan",
+            "inherits": "default-rel",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_C_FLAGS": "-Wall -Wextra -Wfloat-equal -Wtype-limits -Wpointer-arith -Wshadow -Winit-self -fno-diagnostics-show-option -fsanitize=address,leak,undefined",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,leak,undefined"
+            }
         }
     ]
 }

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -888,12 +888,11 @@ sv_strcspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
         return a - str;
     }
     memset(byteset, 0, sizeof byteset);
-    for (size_t i = 0;
-         i < set_sz && BITOP(byteset, *(unsigned char *)set, |=);
+    for (size_t i = 0; i < set_sz && BITOP(byteset, *(unsigned char *)set, |=);
          ++set, ++i)
     {}
-    for (size_t i = 0;
-         i < str_sz && !BITOP(byteset, *(unsigned char *)a, &); ++a)
+    for (size_t i = 0; i < str_sz && !BITOP(byteset, *(unsigned char *)a, &);
+         ++a)
     {}
     return a - str;
 }
@@ -920,12 +919,11 @@ sv_strspn(size_t const str_sz, char const ARR_CONST_GEQ(str, str_sz),
         {}
         return a - str;
     }
-    for (size_t i = 0;
-         i < set_sz && BITOP(byteset, *(unsigned char *)set, |=);
+    for (size_t i = 0; i < set_sz && BITOP(byteset, *(unsigned char *)set, |=);
          ++set, ++i)
     {}
-    for (size_t i = 0;
-         i < str_sz && BITOP(byteset, *(unsigned char *)a, &); ++a, ++i)
+    for (size_t i = 0; i < str_sz && BITOP(byteset, *(unsigned char *)a, &);
+         ++a, ++i)
     {}
     return a - str;
 }
@@ -1503,7 +1501,8 @@ sv_threebyte_strnstrn(size_t const sz, unsigned char const ARR_GEQ(h, sz),
 }
 
 static inline size_t
-sv_rthreebyte_strnstrn(size_t const sz, unsigned char const ARR_CONST_GEQ(h, sz),
+sv_rthreebyte_strnstrn(size_t const sz,
+                       unsigned char const ARR_CONST_GEQ(h, sz),
                        size_t const n_sz,
                        unsigned char const ARR_CONST_GEQ(n, n_sz))
 {

--- a/tests/run_tests.c
+++ b/tests/run_tests.c
@@ -58,6 +58,7 @@ run(str_view const tests_dir)
     size_t tests = 0;
     size_t passed = 0;
     struct dirent const *d;
+    bool fail = false;
     while ((d = readdir(dir_ptr)))
     {
         str_view const entry = sv(d->d_name);
@@ -67,7 +68,7 @@ run(str_view const tests_dir)
         }
         if (!fill_path(absolute_path, tests_dir, entry))
         {
-            return 1;
+            goto done;
         }
         printf("%s(%s%s\n", CYAN, sv_begin(entry), NONE);
         (void)fflush(stdout);
@@ -89,10 +90,12 @@ run(str_view const tests_dir)
         passed += 1 - res;
         ++tests;
     }
-    bool const fail = passed != tests;
+    fail = passed != tests;
     fail
         ? printf("%sPASSED %zu/%zu T_T%s\n\n", RED, passed, tests, NONE)
         : printf("%sPASSED %zu/%zu \\(*.*)/%s\n\n", GREEN, passed, tests, NONE);
+done:
+    closedir(dir_ptr);
     return fail;
 }
 

--- a/tests/test_out_of_bounds.c
+++ b/tests/test_out_of_bounds.c
@@ -1,6 +1,8 @@
 #include "str_view.h"
 #include "test.h"
 
+#include <stddef.h>
+
 int
 main()
 {


### PR DESCRIPTION
These changes add sanitizers to cmake presets making it possible to run sanitized tests. This has caught some bad reads and loads that can be repaired in low level string searching helpers.