### PR TITLE
sz to len

### DIFF
--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -490,8 +490,8 @@ sv_next_tok(str_view const src, str_view const tok, str_view const delim)
     {
         return (str_view){.s = src.s + src.len, .len = 0};
     }
-    size_t const found
-        = sv_strnstrn((ptrdiff_t)next.len, next.s, (ptrdiff_t)delim.len, delim.s);
+    size_t const found = sv_strnstrn((ptrdiff_t)next.len, next.s,
+                                     (ptrdiff_t)delim.len, delim.s);
     return (str_view){.s = next.s, .len = found};
 }
 
@@ -646,10 +646,10 @@ sv_match(str_view const hay, str_view const needle)
     {
         return (str_view){.s = hay.s + hay.len, .len = 0};
     }
-    size_t const found
-        = sv_strnstrn((ptrdiff_t)hay.len, hay.s, (ptrdiff_t)needle.len, needle.s);
+    size_t const found = sv_strnstrn((ptrdiff_t)hay.len, hay.s,
+                                     (ptrdiff_t)needle.len, needle.s);
     return found == hay.len ? (str_view){.s = hay.s + hay.len, .len = 0}
-                           : (str_view){.s = hay.s + found, .len = needle.len};
+                            : (str_view){.s = hay.s + found, .len = needle.len};
 }
 
 str_view
@@ -666,7 +666,7 @@ sv_rmatch(str_view const hay, str_view const needle)
     size_t const found = sv_rstrnstrn((ptrdiff_t)hay.len, hay.s,
                                       (ptrdiff_t)needle.len, needle.s);
     return found == hay.len ? (str_view){.s = hay.s + hay.len, .len = 0}
-                           : (str_view){.s = hay.s + found, .len = needle.len};
+                            : (str_view){.s = hay.s + found, .len = needle.len};
 }
 
 size_t

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -68,7 +68,7 @@
 typedef struct
 {
     char const *s;
-    size_t sz;
+    size_t len;
 } str_view;
 
 /* Standard three way comparison type in C. See the comparison
@@ -128,7 +128,7 @@ SV_API str_view sv_copy(size_t str_sz, char const *src_str)
 
 /* Fills the destination buffer with the minimum between
    destination size and source view size, null terminating
-   the string. This may cut off src data if dest_sz < src.sz.
+   the string. This may cut off src data if dest_sz < src.len.
    Returns how many bytes were written to the buffer. */
 SV_API size_t sv_fill(size_t dest_sz, char *dest_buf, str_view src);
 
@@ -200,7 +200,7 @@ SV_API size_t sv_len(str_view sv) ATTRIB_CONST;
 
 /* Returns the bytes of str_view including null terminator. Note that
    string views may not actually be null terminated but the position at
-   str_view[str_view.sz] is interpreted as the null terminator and thus
+   str_view[str_view.len] is interpreted as the null terminator and thus
    counts towards the byte count. */
 SV_API size_t sv_size(str_view sv) ATTRIB_CONST;
 


### PR DESCRIPTION
The str view field for length of the string should not be sz, that is misleading and makes you think it is the size in bytes, which would include null terminator position. We only want to indicate the number of characters in the string before the null terminator, which may not be present in the view.